### PR TITLE
Ensure rebel mode works on both themes

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,8 +15,7 @@ function applyTheme(theme) {
 function initTheme() {
   try {
     const saved = localStorage.getItem(THEME_KEY);
-    const prefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
-    const theme = saved || (prefersLight ? 'light' : 'dark');
+    const theme = saved || 'dark';
     applyTheme(theme);
   } catch (_) {
     applyTheme('dark');
@@ -513,10 +512,10 @@ function applyRebelMode(isOn) {
 function initRebelMode() {
   try {
     const saved = localStorage.getItem(REBEL_KEY);
-    const isOn = saved ? saved === '1' : false;
+    const isOn = saved ? saved === '1' : true;
     applyRebelMode(isOn);
   } catch (_) {
-    applyRebelMode(false);
+    applyRebelMode(true);
   }
   const toggleEl = document.getElementById('rebelToggle');
   if (toggleEl) {

--- a/style.css
+++ b/style.css
@@ -42,6 +42,21 @@
   --shadow: rgba(0, 0, 0, 0.5);
 }
 
+/* Rebel mode tokens for light theme */
+:root[data-theme="light"].rebel {
+  --bg: #f8f7ff;
+  --bg-gradient: radial-gradient(60% 60% at 50% 50%, rgba(138,92,255,0.06) 0%, rgba(255,255,255,0) 60%), radial-gradient(40% 40% at 20% 80%, rgba(255,46,99,0.08) 0%, rgba(255,255,255,0) 60%), radial-gradient(40% 40% at 80% 20%, rgba(0,245,160,0.08) 0%, rgba(255,255,255,0) 60%);
+  --card: #ffffff;
+  --card-hover: #f3f4f8;
+  --text: #111827;
+  --text-muted: #4b5563;
+  --accent: #ff2e63;
+  --accent2: #00b884;
+  --accent3: #7b5cff;
+  --border: #e5e7eb;
+  --shadow: rgba(99, 102, 241, 0.12);
+}
+
 * {
   box-sizing: border-box;
   margin: 0;
@@ -78,6 +93,12 @@ body::before {
   mix-blend-mode: overlay;
   z-index: -1;
 }
+
+/* Softer grain in light Rebel */
+:root[data-theme="light"].rebel body::after {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%' height='100%' filter='url(%23n)' opacity='0.025'/></svg>");
+  mix-blend-mode: multiply;
+}
 header {
   padding: 30px 20px;
   max-width: 1200px;
@@ -112,6 +133,12 @@ header {
   color: var(--bg);
   border-color: var(--bg);
   box-shadow: 0 2px 0 #000;
+}
+
+/* Better contrast for pressed REBEL on light Rebel */
+:root[data-theme="light"].rebel .zine-tab[aria-pressed="true"] {
+  color: #fff;
+  border-color: #fff;
 }
 /* Tiny tear effect */
 .zine-tab::after {


### PR DESCRIPTION
Enable Rebel mode for both light and dark themes and set dark theme with Rebel as default.

Rebel mode now functions correctly on both light and dark themes by introducing dedicated CSS tokens for `:root[data-theme="light"].rebel` and softening the grain overlay for the light Rebel theme. The default theme is now `dark` and Rebel mode is `on` when no settings are saved in `localStorage`, as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-2192c03a-6580-4395-aaee-9cf976f2611e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2192c03a-6580-4395-aaee-9cf976f2611e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

